### PR TITLE
Added -h/--hostname option

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -26,10 +26,15 @@ import urllib2
 
 graphite = Plugin("Plugin to retrieve data from graphite", "1.0")
 graphite.add_option("u", "url", "URL to query for data", required=True)
+graphite.add_option("H", "hostname", "Host name to use in the URL")
 
 graphite.enable_status("warning")
 graphite.enable_status("critical")
 graphite.start()
+
+if graphite.options.hostname:
+  graphite.options.url = graphite.options.url.replace('@HOSTNAME@', 
+    graphite.options.hostname.replace('.','_'))
 
 usock = urllib2.urlopen(graphite.options.url)
 data = usock.read()


### PR DESCRIPTION
If present then it will:
1. Replace all "." by "_", according to Graphite's convention.
2. Interpolate any @HOSTNAME@ which appears in the URL by the value of that string.

(note that github for some reason keeps lower-casing HOSTNAME, it's actually upper case. I'm trying to keep close to Nagios' $HOSTNAME$ convention)
