### PR TITLE
Add a sum function for aggregating events/errors

### DIFF
--- a/check_graphite
+++ b/check_graphite
@@ -35,11 +35,15 @@ def f_min(values):
 def f_max(values):
   return max(values)
 
+def f_sum(values):
+  return sum(values)
+
 functionmap = {
   "avg":{  "label": "average", "function": f_avg },
   "last":{ "label": "last",    "function": f_last },
   "min":{  "label": "minimum", "function": f_min },
   "max":{  "label": "maximum", "function": f_max },
+  "sum":{  "label": "sum",  "function": f_sum },
 }
 
 graphite = Plugin("Plugin to retrieve data from graphite", "1.0")


### PR DESCRIPTION
I tried to handle this in graphite with the summarize() function, but check_graphite breaks when it only scrapes one float from the rawData (because of the problem outlined in issue #7 - dropping the last value from the list). This is useful for people who use graphite for logging events or errors (we write error counts from celery tasks to graphite).
