### PR TITLE
Add multi lines support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@ Nagios plugin to poll Graphite
 What does it do? How does it work? How do I run it?
 ---
 
-This is a Nagios plugin, so you install it and configure a service check in Nagios and it runs whenever Nagios calls it and reports back on the status of whatever it's monitoring. It takes one parameter (`-u`) which tells it the Graphite URL to monitor, for example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`. When run, it will query that URL and treat the average of the values returned as the 'value' to be compared against the warning/critical thresholds, and return this value to Nagios as performance data. See Graphite's URL API documentation to generate the URL parameter.
+This is a Nagios plugin, so you install it and configure a service check in Nagios and it runs whenever Nagios calls it and reports back on the status of whatever it's monitoring. It has one required parameter (`-u`) which tells it the Graphite URL to monitor, for example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`. When run, it will query that URL and treat the average of the values returned as the 'value' to be compared against the warning/critical thresholds, and return this value to Nagios as performance data. See Graphite's URL API documentation to generate the URL parameter.
+
+Usage
+---
+Usage: check_graphite -u URL [-U USERNAME] [-P PASSWORD] [-H HOSTNAME] [-n NONE] [-f FUNCTION] [-w WARNING] [-c CRITICAL]
+
+Plugin to retrieve data from graphite
+
+Options:
+`    -h, --help            show this help message and exit  
+    -V, --version         show program's version number and exit  
+    -v, --verbose         Get more verbose status output. Can be specified up to three times  
+    -u URL, --url=URL     URL to query for data  
+    -U USERNAME, --username=USERNAME User for authentication  
+    -P PASSWORD, --password=PASSWORD Password for authentication  
+    -H HOSTNAME, --hostname=HOSTNAME Host name to use in the URL  
+    -n NONE, --none=NONE  Ignore None values: 'yes' or 'no' (default no)  
+    -f FUNCTION, --function=FUNCTION Function to run on retrieved values: avg/min/max/last/sum (default 'avg')  
+    -w WARNING, --warning=WARNING Set the warning notification level.  
+    -c CRITICAL, --critical=CRITICAL Set the critical notification level.  `
 
 Dependencies
 ---

--- a/README.md
+++ b/README.md
@@ -1,22 +1,29 @@
 Nagios plugin to poll Graphite
-===
+==============================
 
 What does it do? How does it work? How do I run it?
----
+---------------------------------------------------
 
-This is a Nagios plugin, so you install it and configure a service
-check in Nagios and it runs whenever Nagios calls it and reports
-back on the status of whatever it's monitoring. It has one required
-parameter (`-u`) which tells it the Graphite URL to monitor, for
-example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`.
-When run, it will query that URL and treat the average of the
-values returned as the 'value' to be compared against the
-warning/critical thresholds, and return this value to Nagios as
-performance data. See Graphite's URL API documentation to generate
+This is a Nagios plugin. Install it and configure a service
+check in Nagios and it will run whenever Nagios calls it and
+will report back on the status of whatever it's monitoring.
+
+It has one required parameter `-u` which tells it the Graphite
+URL to monitor, for example:
+
+    http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`
+
+When run, it will query that URL, calculate the average (or
+another function) of the recieved values, compare the average
+to the warning/critical thresholds, and return the value to
+Nagios as performance data.
+
+See Graphite's URL API documentation on how to generate
 the URL parameter.
 
 Usage
----
+-----
+
 ```
 Usage: check_graphite -u URL [-U USERNAME] [-P PASSWORD] [-H HOSTNAME] [-n NONE] [-f FUNCTION] [-w WARNING] [-c CRITICAL]
 
@@ -37,7 +44,7 @@ Options:
 ```
 
 Dependencies
----
+------------
 
 Python 2.6+
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ Nagios plugin to poll Graphite
 What does it do? How does it work? How do I run it?
 ---
 
-This is a Nagios plugin, so you install it and configure a service check in Nagios and it runs whenever Nagios calls it and reports back on the status of whatever it's monitoring. It has one required parameter (`-u`) which tells it the Graphite URL to monitor, for example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`. When run, it will query that URL and treat the average of the values returned as the 'value' to be compared against the warning/critical thresholds, and return this value to Nagios as performance data. See Graphite's URL API documentation to generate the URL parameter.
+This is a Nagios plugin, so you install it and configure a service
+check in Nagios and it runs whenever Nagios calls it and reports
+back on the status of whatever it's monitoring. It has one required
+parameter (`-u`) which tells it the Graphite URL to monitor, for
+example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`.
+When run, it will query that URL and treat the average of the
+values returned as the 'value' to be compared against the
+warning/critical thresholds, and return this value to Nagios as
+performance data. See Graphite's URL API documentation to generate
+the URL parameter.
 
 Usage
 ---

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage
 -----
 
 ```
-Usage: check_graphite -u URL [-U USERNAME] [-P PASSWORD] [-H HOSTNAME] [-n NONE] [-f FUNCTION] [-w WARNING] [-c CRITICAL]
+Usage: check_graphite -u URL [-U USERNAME] [-P PASSWORD] [-H HOSTNAME] [-n NONE] [-f FUNCTION] -w WARNING -c CRITICAL
 
 Plugin to retrieve data from graphite
 
@@ -39,8 +39,8 @@ Options:
     -H HOSTNAME, --hostname=HOSTNAME  Host name to use in the URL
     -n NONE,     --none=NONE          Ignore None values: 'yes' or 'no' (default no)
     -f FUNCTION, --function=FUNCTION  Function to run on retrieved values: avg/min/max/last/sum (default 'avg')
-    -w WARNING,  --warning=WARNING    Set the warning notification level.
-    -c CRITICAL, --critical=CRITICAL  Set the critical notification level.
+    -w WARNING,  --warning=WARNING    Set the warning notification level (required)
+    -c CRITICAL, --critical=CRITICAL  Set the critical notification level (required)
 ```
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -8,22 +8,24 @@ This is a Nagios plugin, so you install it and configure a service check in Nagi
 
 Usage
 ---
+```
 Usage: check_graphite -u URL [-U USERNAME] [-P PASSWORD] [-H HOSTNAME] [-n NONE] [-f FUNCTION] [-w WARNING] [-c CRITICAL]
 
 Plugin to retrieve data from graphite
 
 Options:
-`    -h, --help            show this help message and exit  
-    -V, --version         show program's version number and exit  
-    -v, --verbose         Get more verbose status output. Can be specified up to three times  
-    -u URL, --url=URL     URL to query for data  
-    -U USERNAME, --username=USERNAME User for authentication  
-    -P PASSWORD, --password=PASSWORD Password for authentication  
-    -H HOSTNAME, --hostname=HOSTNAME Host name to use in the URL  
-    -n NONE, --none=NONE  Ignore None values: 'yes' or 'no' (default no)  
-    -f FUNCTION, --function=FUNCTION Function to run on retrieved values: avg/min/max/last/sum (default 'avg')  
-    -w WARNING, --warning=WARNING Set the warning notification level.  
-    -c CRITICAL, --critical=CRITICAL Set the critical notification level.  `
+    -h,          --help               show this help message and exit
+    -V,          --version            show program's version number and exit
+    -v,          --verbose            Get more verbose status output. Can be specified up to three times
+    -u URL,      --url=URL            URL to query for data
+    -U USERNAME, --username=USERNAME  User for authentication
+    -P PASSWORD, --password=PASSWORD  Password for authentication
+    -H HOSTNAME, --hostname=HOSTNAME  Host name to use in the URL
+    -n NONE,     --none=NONE          Ignore None values: 'yes' or 'no' (default no)
+    -f FUNCTION, --function=FUNCTION  Function to run on retrieved values: avg/min/max/last/sum (default 'avg')
+    -w WARNING,  --warning=WARNING    Set the warning notification level.
+    -c CRITICAL, --critical=CRITICAL  Set the critical notification level.
+```
 
 Dependencies
 ---

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Options:
     -c CRITICAL, --critical=CRITICAL  Set the critical notification level (required)
 ```
 
+Example
+-------
+
+    check_graphite -u http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true -w 10,20 -c 20,30
+
 Dependencies
 ------------
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Dependencies
 
 Python 2.6+
 
-You'll need to have NagAconda installed (e.g. `easy_install nagaconda`)
+You'll need to have NagAconda installed (e.g. `easy_install nagaconda` or `pip install nagaconda`)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options:
     -h,          --help               show this help message and exit
     -V,          --version            show program's version number and exit
     -v,          --verbose            Get more verbose status output. Can be specified up to three times
-    -u URL,      --url=URL            URL to query for data
+    -u URL,      --url=URL            URL to query for data (required)
     -U USERNAME, --username=USERNAME  User for authentication
     -P PASSWORD, --password=PASSWORD  Password for authentication
     -H HOSTNAME, --hostname=HOSTNAME  Host name to use in the URL

--- a/check_graphite
+++ b/check_graphite
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2011 Recoset <nicolas@recoset.com>
 # 

--- a/check_graphite
+++ b/check_graphite
@@ -52,6 +52,7 @@ graphite.add_option("U", "username", "User for authentication")
 graphite.add_option("P", "password", "Password for authentication")
 graphite.add_option("H", "hostname", "Host name to use in the URL")
 graphite.add_option("n", "none", "Ignore None values: 'yes' or 'no' (default no)")
+graphite.add_option("s", "status_message", "Status Message (default function value of metric: value)",default=None)
 graphite.add_option("f", "function", "Function to run on retrieved values: avg/min/max/last/sum (default 'avg')",
   default="avg")
 
@@ -79,25 +80,32 @@ usock.close()
 if graphite.options.function not in functionmap:
   graphite.unknown_error("Bad function name given to -f/--function option: '%s'" % graphite.options.function)
 
-try:
-  pieces = data.split("|")
-  counter = pieces[0].split(",")[0]
-  values = pieces[1].split(",")[:-1]
-  if len(data.strip().split('\n')) > 1:
-    raise 'Graphite returned multiple lines'
-except:
-  graphite.unknown_error("Graphite returned bad data")
+counter=None
+values=None
 
-if graphite.options.none == 'yes':
-  values = map(lambda x: float(x), filter(lambda x: x != 'None', values))
-else:
-  values = map(lambda x: 0.0 if x == 'None' else float(x), values)
-if len(values) == 0:
-  graphite.unknown_error("Graphite returned an empty list of values")
-else:
-  value = functionmap[graphite.options.function]["function"](values)
+mdata = data.strip().split('\n')
+for d in mdata:
+  try:
+    pieces = d.split("|")
+    counter = pieces[0].split(",")[0]
+    values = pieces[1].split(",")[:-1]
+  except:
+    graphite.unknown_error("Graphite returned bad data")
 
-graphite.set_value(counter, value)
-graphite.set_status_message("%s value of %s: %f" % (functionmap[graphite.options.function]["label"], counter, value))
+  if graphite.options.none == 'yes':
+      values = map(lambda x: float(x), filter(lambda x: x != 'None', values))
+  else:
+    values = map(lambda x: 0.0 if x == 'None' else float(x), values)
+  if len(values) == 0:
+    graphite.unknown_error("Graphite returned an empty list of values")
+  else:
+    value = functionmap[graphite.options.function]["function"](values)
+
+  graphite.set_value(counter, value)
+
+if graphite.options.status_message:
+  graphite.set_status_message(graphite.options.status_message)
+else:
+  graphite.set_status_message("%s value of %s: %f" % (functionmap[graphite.options.function]["label"], counter, value))
 
 graphite.finish()

--- a/check_graphite
+++ b/check_graphite
@@ -47,7 +47,7 @@ functionmap = {
 }
 
 graphite = Plugin("Plugin to retrieve data from graphite", "1.0")
-graphite.add_option("u", "url", "URL to query for data", required=True)
+graphite.add_option("u", "url", "URL to query for data (required)", required=True)
 graphite.add_option("U", "username", "User for authentication")
 graphite.add_option("P", "password", "Password for authentication")
 graphite.add_option("H", "hostname", "Host name to use in the URL")

--- a/check_graphite
+++ b/check_graphite
@@ -88,7 +88,7 @@ for d in mdata:
   try:
     pieces = d.split("|")
     counter = pieces[0].split(",")[0]
-    values = pieces[1].split(",")[:-1]
+    values = pieces[1].split(",")
   except:
     graphite.unknown_error("Graphite returned bad data")
 


### PR DESCRIPTION
Here is a patch to support multi-lines returned by graphite (and with a custom status message).
You can now use this plugin to check multiple values like : 

./check_graphite.py -u 'http://graphite/rend?targer=carbon.agents.*.cache.queues" -w 500 -c 1000 -s "Carbon queue"

Olivier
