### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##No longer maintained...
+## No longer maintained...
 
 We no longer use this script internally so we are no longer maintaining it. Unfortunately, that means we won't accept any pull requests, but if you make some improvements, we would be happy to link to your repo.
 
@@ -6,13 +6,13 @@ Here are some forks which have useful improvements:
 
 * Support for multiple lines: https://github.com/olivierHa/check_graphite
 
-##Nagios plugin to poll Graphite
+## Nagios plugin to poll Graphite
 
-###What does it do? How does it work? How do I run it?
+### What does it do? How does it work? How do I run it?
 
 This is a Nagios plugin, so you install it and configure a service check in Nagios and it runs whenever Nagios calls it and reports back on the status of whatever it's monitoring. It takes one parameter (`-u`) which tells it the Graphite URL to monitor, for example `http://server/render?target=stats.auctionStart&from=-1minutes&rawData=true`. When run, it will query that URL and treat the average of the values returned as the 'value' to be compared against the warning/critical thresholds, and return this value to Nagios as performance data. See Graphite's URL API documentation to generate the URL parameter.
 
-###Dependencies
+### Dependencies
 
 Python 2.6+
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
